### PR TITLE
Simplify HTTP logic and introduce resolver timeout

### DIFF
--- a/check_mysql.go
+++ b/check_mysql.go
@@ -36,7 +36,7 @@ func (m *Monitor) checkMySQL(site *Site) error {
 	LIMIT 1
 	`
 	var name string
-	ctx, cFunc := context.WithDeadline(context.Background(), time.Now().Add(time.Duration(site.TimeoutSeconds)*time.Second))
+	ctx, cFunc := context.WithDeadline(context.Background(), time.Now().Add(time.Duration(site.TimeoutMillis)*time.Millisecond))
 	defer cFunc()
 
 	tb := time.Now()

--- a/check_sqlserver.go
+++ b/check_sqlserver.go
@@ -38,7 +38,7 @@ func (m *Monitor) checkSQLServer(site *Site) error {
 	FROM sys.tables
 	`
 	var name string
-	ctx, cFunc := context.WithDeadline(context.Background(), time.Now().Add(time.Duration(site.TimeoutSeconds)*time.Second))
+	ctx, cFunc := context.WithDeadline(context.Background(), time.Now().Add(time.Duration(site.TimeoutMillis)*time.Millisecond))
 	defer cFunc()
 
 	tb := time.Now()

--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
     },
     "heartbeatSeconds": 600,
     "resolverAddress": "8.8.8.8",
+    "resolverTimeoutMillis": 500,
     "sites": [
         {
             "server": "www.example.com",
@@ -17,7 +18,7 @@
                 "method": "POST",
                 "body": "<unescaped body>"
             },
-            "timeoutSeconds": 5,
+            "timeoutMillis": 5000,
             "recipients": [
                 "a@example.com",
                 "b@example.com"
@@ -31,7 +32,7 @@
                 "username": "<username>",
                 "password": "<secret>"
             },
-            "timeoutSeconds": 2,
+            "timeoutMillis": 2000,
             "recipients": [
                 "c@example.com",
                 "d@example.com"

--- a/types.go
+++ b/types.go
@@ -23,7 +23,7 @@ type Site struct {
 	HTTPConfig      HTTPConfig      `json:"http"`
 	MySQLConfig     MySQLConfig     `json:"mysql"`
 	SQLServerConfig SQLServerConfig `json:"sqlserver"`
-	TimeoutSeconds  int64           `json:"timeoutSeconds"`
+	TimeoutMillis   int64           `json:"timeoutMillis"`
 	Recipients      []string        `json:"recipients"`
 }
 
@@ -53,11 +53,11 @@ type SQLServerConfig struct {
 
 // Config holds the monitor's configuration.
 type Config struct {
-	Sender                 SenderConfig `json:"sender"`
-	HeartbeatSeconds       int          `json:"heartbeatSeconds"`
-	ResolverAddress        string       `json:"resolverAddress"`
-	ResolverTimeoutSeconds int          `json:"resolverTimeoutSeconds"`
-	Sites                  []Site       `json:"sites"`
+	Sender                SenderConfig `json:"sender"`
+	HeartbeatSeconds      int          `json:"heartbeatSeconds"`
+	ResolverAddress       string       `json:"resolverAddress"`
+	ResolverTimeoutMillis int          `json:"resolverTimeoutMillis"`
+	Sites                 []Site       `json:"sites"`
 }
 
 // Monitor monitors the heartbeat of the servers specified in the


### PR DESCRIPTION
* Logging is now done even when an error occurs.
* Resolver and site-level timeouts are now in milliseconds (not seconds).